### PR TITLE
n-gram Experiment 

### DIFF
--- a/examples/ngram.ipynb
+++ b/examples/ngram.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "id": "7b6ecdcc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torchhd.functional import bind,multibind,multiset,permute,random_hv,ngrams as ngrams_base\n",
+    "\n",
+    "def ngrams_unbind(input, n=3):\n",
+    "    unbinded = torch.unbind(input, -2)\n",
+    "    permuted=[permute(torch.stack(unbinded[i:-(n-1 - i)]), shifts=n - i - 1) for i in range(n-1)]\n",
+    "    permuted.append(torch.stack(unbinded[n-1:]))\n",
+    "    permuted=multibind(torch.stack(permuted, -2))\n",
+    "    return multiset(permuted)\n",
+    "\n",
+    "def ngrams_forloop(input, n=3):\n",
+    "    n_gram = permute(input[..., :-(n-1), :], shifts=n-1)\n",
+    "    for i in range(1, n-1):\n",
+    "        n_gram=bind(n_gram,permute(input[..., i:-(n-1 - i), :], shifts=n-1 - i))\n",
+    "    n_gram=bind(n_gram,input[...,n-1:,:])\n",
+    "    return multiset(n_gram)\n",
+    "\n",
+    "def ngrams_in_place(input, n=3):\n",
+    "    n_gram = permute(input[..., :-(n-1), :], shifts=n-1)\n",
+    "    for i in range(1, n-1):\n",
+    "        n_gram.mul_(permute(input[..., i:-(n-1 - i), :], shifts=n-1 - i))\n",
+    "    n_gram.mul_(input[...,n-1:,:])\n",
+    "    return multiset(n_gram)\n",
+    "\n",
+    "def ngrams_index_select(input, n=3):\n",
+    "    length = input.size(-2)\n",
+    "    n_gram = permute(torch.index_select(input,-2,torch.arange(length-(n-1))), shifts=n-1)\n",
+    "    for i in range(1, n-1):\n",
+    "        n_gram.mul_(permute(torch.index_select(input,-2,torch.arange(i,length-(n-1 - i))), shifts=n-1 - i))\n",
+    "    n_gram.mul_(torch.index_select(input,-2,torch.arange(n-1,length)))\n",
+    "    return multiset(n_gram)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "id": "de9cb1ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "134 µs ± 4.1 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n",
+      "262 µs ± 9.69 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n",
+      "132 µs ± 3.62 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n",
+      "122 µs ± 1.74 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n",
+      "162 µs ± 2.18 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "x = random_hv(10, 10000)\n",
+    "%timeit ngrams_base(x)\n",
+    "%timeit ngrams_unbind(x)\n",
+    "%timeit ngrams_forloop(x)\n",
+    "%timeit ngrams_in_place(x)\n",
+    "%timeit ngrams_index_select(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abc4e956",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
random_hv(10, 10000)
ngrams_base: 134 µs ± 4.1 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
ngrams_unbind: 262 µs ± 9.69 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
ngrams_forloop: 132 µs ± 3.62 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
ngrams_in_place: 122 µs ± 1.74 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
ngrams_index_select: 162 µs ± 2.18 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)