### PR TITLE
Add universal cosine and dot similarity support

### DIFF
--- a/torchhd/__init__.py
+++ b/torchhd/__init__.py
@@ -13,6 +13,8 @@ from torchhd.functional import (
     unbind,
     bundle,
     permute,
+    cosine_similarity,
+    dot_similarity,
 )
 
 from torchhd.version import __version__
@@ -31,4 +33,6 @@ __all__ = [
     "unbind",
     "bundle",
     "permute",
+    "cosine_similarity",
+    "dot_similarity",
 ]

--- a/torchhd/tests/basis_hv/test_circular_hv.py
+++ b/torchhd/tests/basis_hv/test_circular_hv.py
@@ -68,7 +68,7 @@ class TestCircular_hv:
 
             abs_sims_diff = sims_diff.abs()
             assert torch.all(
-                (0.248 < abs_sims_diff) & (abs_sims_diff < 0.252)
+                (0.247 < abs_sims_diff) & (abs_sims_diff < 0.253)
             ).item(), "similarity changes linearly"
         else:
             sims = functional.hamming_similarity(hv[0], hv).float() / 1000000

--- a/torchhd/tests/basis_hv/test_level_hv.py
+++ b/torchhd/tests/basis_hv/test_level_hv.py
@@ -67,7 +67,7 @@ class TestLevel_hv:
             sims = functional.cosine_similarity(hv[0], hv)
             sims_diff = sims[:-1] - sims[1:]
             assert torch.all(
-                (0.248 < sims_diff) & (sims_diff < 0.252)
+                (0.247 < sims_diff) & (sims_diff < 0.253)
             ).item(), "similarity decreases linearly"
         else:
             sims = functional.hamming_similarity(hv[0], hv).float() / 10000

--- a/torchhd/tests/test_similarities.py
+++ b/torchhd/tests/test_similarities.py
@@ -278,3 +278,132 @@ class TestCosSimilarity:
         similarity = functional.cosine_similarity(hv, hv)
 
         assert similarity.device == device
+
+class TestHammingSimilarity:
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_shape(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        similarity = functional.hamming_similarity(hv[0], hv[1])
+        assert similarity.shape == ()
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        similarity = functional.hamming_similarity(hv[0], hv)
+        assert similarity.shape == (2,)
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        hv2 = functional.random_hv(4, 100, generator=generator, dtype=dtype)
+        similarity = functional.hamming_similarity(hv, hv2)
+        assert similarity.shape == (2, 4)
+
+        hv1 = functional.random_hv(6, 100, generator=generator, dtype=dtype).view(
+            2, 3, 100
+        )
+        hv2 = functional.random_hv(4, 100, generator=generator, dtype=dtype)
+        similarity = functional.hamming_similarity(hv1, hv2)
+        assert similarity.shape == (2, 3, 4)
+
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_value(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        if dtype == torch.bool:
+            hv = torch.tensor(
+                [
+                    [1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 1, 0, 0, 1, 0, 1, 1],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.hamming_similarity(hv, hv)
+            exp = torch.tensor([[10, 7], [7, 10]], dtype=torch.long)
+            assert torch.all(res == exp).item()
+
+        elif dtype in torch_complex_dtypes:
+            hv = torch.tensor(
+                [
+                    [
+                        -0.2510 + 0.9680j,
+                        0.0321 + 0.9995j,
+                        -0.6063 - 0.7953j,
+                        -0.4006 - 0.9162j,
+                        0.4987 - 0.8667j,
+                        -0.3252 - 0.9456j,
+                        -0.2784 + 0.9605j,
+                        -0.8563 + 0.5165j,
+                        0.9061 + 0.4231j,
+                        -0.3801 - 0.9250j,
+                    ],
+                    [
+                        -0.9610 + 0.2766j,
+                        0.9879 - 0.1551j,
+                        -0.4111 - 0.9116j,
+                        -0.8185 + 0.5744j,
+                        -0.8123 + 0.5833j,
+                        0.2966 + 0.9550j,
+                        -0.9958 - 0.0915j,
+                        0.8630 - 0.5052j,
+                        -0.1480 - 0.9890j,
+                        0.5285 - 0.8489j,
+                    ],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.hamming_similarity(hv, hv)
+            exp = torch.tensor([[10, 0], [0, 10]], dtype=torch.long)
+            assert torch.all(res == exp).item()
+
+        else:
+            hv = torch.tensor(
+                [
+                    [1, 1, -1, 1, -1, 1, -1, 1, -1, 1],
+                    [1, -1, -1, 1, 1, -1, 1, -1, 1, -1],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.hamming_similarity(hv, hv)
+            exp = torch.tensor([[10, 3], [3, 10]], dtype=torch.long)
+            assert torch.all(res == exp).item()
+
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_dtype(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        hv = functional.random_hv(3, 100, generator=generator, dtype=dtype)
+
+        similarity = functional.hamming_similarity(hv, hv)
+
+        assert similarity.dtype == torch.long
+
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_device(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        hv = functional.random_hv(
+            3, 100, generator=generator, dtype=dtype, device=device
+        )
+
+        similarity = functional.hamming_similarity(hv, hv)
+
+        assert similarity.device == device

--- a/torchhd/tests/test_similarities.py
+++ b/torchhd/tests/test_similarities.py
@@ -132,6 +132,23 @@ class TestDotSimilarity:
         else:
             assert similarity.dtype == dtype
 
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_device(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        hv = functional.random_hv(
+            3, 100, generator=generator, dtype=dtype, device=device
+        )
+
+        similarity = functional.dot_similarity(hv, hv)
+
+        assert similarity.device == device
+
 
 class TestCosSimilarity:
     @pytest.mark.parametrize("dtype", torch_dtypes)
@@ -244,3 +261,20 @@ class TestCosSimilarity:
         similarity = functional.cosine_similarity(hv, hv)
 
         assert similarity.dtype == torch.float
+
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_device(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        hv = functional.random_hv(
+            3, 100, generator=generator, dtype=dtype, device=device
+        )
+
+        similarity = functional.cosine_similarity(hv, hv)
+
+        assert similarity.device == device

--- a/torchhd/tests/test_similarities.py
+++ b/torchhd/tests/test_similarities.py
@@ -1,0 +1,246 @@
+import pytest
+import torch
+
+from torchhd import functional
+
+from .utils import (
+    torch_dtypes,
+    torch_complex_dtypes,
+    supported_dtype,
+)
+
+seed = 2147483644
+
+
+class TestDotSimilarity:
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_shape(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        similarity = functional.dot_similarity(hv[0], hv[1])
+        assert similarity.shape == ()
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        similarity = functional.dot_similarity(hv[0], hv)
+        assert similarity.shape == (2,)
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        hv2 = functional.random_hv(4, 100, generator=generator, dtype=dtype)
+        similarity = functional.dot_similarity(hv, hv2)
+        assert similarity.shape == (2, 4)
+
+        hv1 = functional.random_hv(6, 100, generator=generator, dtype=dtype).view(
+            2, 3, 100
+        )
+        hv2 = functional.random_hv(4, 100, generator=generator, dtype=dtype)
+        similarity = functional.dot_similarity(hv1, hv2)
+        assert similarity.shape == (2, 3, 4)
+
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_value(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        if dtype == torch.bool:
+            hv = torch.tensor(
+                [
+                    [1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 1, 0, 0, 1, 0, 1, 1],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.dot_similarity(hv, hv)
+            exp = torch.tensor([[10, 4], [4, 10]], dtype=torch.long)
+            assert torch.all(res == exp).item()
+
+        elif dtype in torch_complex_dtypes:
+            hv = torch.tensor(
+                [
+                    [
+                        -0.2510 + 0.9680j,
+                        0.0321 + 0.9995j,
+                        -0.6063 - 0.7953j,
+                        -0.4006 - 0.9162j,
+                        0.4987 - 0.8667j,
+                        -0.3252 - 0.9456j,
+                        -0.2784 + 0.9605j,
+                        -0.8563 + 0.5165j,
+                        0.9061 + 0.4231j,
+                        -0.3801 - 0.9250j,
+                    ],
+                    [
+                        -0.9610 + 0.2766j,
+                        0.9879 - 0.1551j,
+                        -0.4111 - 0.9116j,
+                        -0.8185 + 0.5744j,
+                        -0.8123 + 0.5833j,
+                        0.2966 + 0.9550j,
+                        -0.9958 - 0.0915j,
+                        0.8630 - 0.5052j,
+                        -0.1480 - 0.9890j,
+                        0.5285 - 0.8489j,
+                    ],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.dot_similarity(hv, hv)
+            out_dtype = torch.float if dtype == torch.complex64 else torch.double
+            exp = torch.tensor([[10.0, -1.5274], [-1.5274, 10.0]], dtype=out_dtype)
+            assert torch.allclose(res, exp)
+
+        else:
+            hv = torch.tensor(
+                [
+                    [1, 1, -1, 1, -1, 1, -1, 1, -1, 1],
+                    [1, -1, -1, 1, 1, -1, 1, -1, 1, -1],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.dot_similarity(hv, hv)
+            exp = torch.tensor([[10, -4], [-4, 10]], dtype=dtype)
+            assert torch.all(res == exp).item()
+
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_dtype(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        hv = functional.random_hv(3, 100, generator=generator, dtype=dtype)
+
+        similarity = functional.dot_similarity(hv, hv)
+
+        if dtype == torch.bool:
+            assert similarity.dtype == torch.long
+        elif dtype == torch.complex64:
+            assert similarity.dtype == torch.float
+        elif dtype == torch.complex128:
+            assert similarity.dtype == torch.double
+        else:
+            assert similarity.dtype == dtype
+
+
+class TestCosSimilarity:
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_shape(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        similarity = functional.cosine_similarity(hv[0], hv[1])
+        assert similarity.shape == ()
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        similarity = functional.cosine_similarity(hv[0], hv)
+        assert similarity.shape == (2,)
+
+        hv = functional.random_hv(2, 100, generator=generator, dtype=dtype)
+        hv2 = functional.random_hv(4, 100, generator=generator, dtype=dtype)
+        similarity = functional.cosine_similarity(hv, hv2)
+        assert similarity.shape == (2, 4)
+
+        hv1 = functional.random_hv(6, 100, generator=generator, dtype=dtype).view(
+            2, 3, 100
+        )
+        hv2 = functional.random_hv(4, 100, generator=generator, dtype=dtype)
+        similarity = functional.cosine_similarity(hv1, hv2)
+        assert similarity.shape == (2, 3, 4)
+
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_value(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        if dtype == torch.bool:
+            hv = torch.tensor(
+                [
+                    [1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 1, 0, 0, 1, 0, 1, 1],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.cosine_similarity(hv, hv)
+            exp = torch.tensor([[1, 0.4], [0.4, 1]], dtype=torch.float)
+            assert torch.allclose(res, exp)
+
+        elif dtype in torch_complex_dtypes:
+            hv = torch.tensor(
+                [
+                    [
+                        -0.2510 + 0.9680j,
+                        0.0321 + 0.9995j,
+                        -0.6063 - 0.7953j,
+                        -0.4006 - 0.9162j,
+                        0.4987 - 0.8667j,
+                        -0.3252 - 0.9456j,
+                        -0.2784 + 0.9605j,
+                        -0.8563 + 0.5165j,
+                        0.9061 + 0.4231j,
+                        -0.3801 - 0.9250j,
+                    ],
+                    [
+                        -0.9610 + 0.2766j,
+                        0.9879 - 0.1551j,
+                        -0.4111 - 0.9116j,
+                        -0.8185 + 0.5744j,
+                        -0.8123 + 0.5833j,
+                        0.2966 + 0.9550j,
+                        -0.9958 - 0.0915j,
+                        0.8630 - 0.5052j,
+                        -0.1480 - 0.9890j,
+                        0.5285 - 0.8489j,
+                    ],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.cosine_similarity(hv, hv)
+            exp = torch.tensor([[1.0, -0.15274], [-0.15274, 1.0]], dtype=torch.float)
+            assert torch.allclose(res, exp)
+
+        else:
+            hv = torch.tensor(
+                [
+                    [1, 1, -1, 1, -1, 1, -1, 1, -1, 1],
+                    [1, -1, -1, 1, 1, -1, 1, -1, 1, -1],
+                ],
+                dtype=dtype,
+            )
+
+            res = functional.cosine_similarity(hv, hv)
+            exp = torch.tensor([[1, -0.4], [-0.4, 1]], dtype=torch.float)
+            assert torch.allclose(res, exp)
+
+    @pytest.mark.parametrize("dtype", torch_dtypes)
+    def test_dtype(self, dtype):
+        if not supported_dtype(dtype):
+            return
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        hv = functional.random_hv(3, 100, generator=generator, dtype=dtype)
+
+        similarity = functional.cosine_similarity(hv, hv)
+
+        assert similarity.dtype == torch.float


### PR DESCRIPTION
All the supported hypervector types are now also supported by `cosine_similarity`, `dot_similarity` and `hamming_similarity`. Based on @rgayler's comments in #72 and #80 we will keep the three different similarity functions but make all of them work for all the supported hypervector types. The two most used similarities, `cosine_similarity` and `dot_similarity` are also aliased for easy access. The `hamming_similarity` is kept as a helper function for the analysis of certain binary processes.