### PR TITLE
Add functional creation of graph

### DIFF
--- a/docs/functional.rst
+++ b/docs/functional.rst
@@ -63,6 +63,7 @@ Encodings
     hash_table
     cross_product
     ngrams
+    graph
 
 
 Utilities

--- a/torchhd/structures.py
+++ b/torchhd/structures.py
@@ -911,6 +911,26 @@ class Graph:
         """
         self.value.fill_(0.0)
 
+    @classmethod
+    def from_edges(cls, input: Tensor, directed=False):
+        """Creates a graph from a tensor
+
+        See: :func:`~torchhd.functional.graph`.
+
+        Args:
+            input (Tensor): tensor containing pairs of node hypervectors that share an edge.
+            directed (bool, optional): specify if the graph is directed or not. Default: ``False``.
+
+        Examples::
+            >>> edges = torch.tensor([[0, 0, 1, 2], [1, 2, 2, 3]])
+            >>> node_embedding = embeddings.Random(4, 10000)
+            >>> edges_hv = node_embedding(edges)
+            >>> graph = structures.Graph.from_edges(edges_hv)
+
+        """
+        value = functional.graph(input, directed=directed)
+        return cls(value, directed=directed)
+
 
 class Tree:
     """Hypervector-based tree data structure.

--- a/torchhd/tests/structures/test_graph.py
+++ b/torchhd/tests/structures/test_graph.py
@@ -179,3 +179,25 @@ class TestGraph:
         assert torch.equal(
             G.value, torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
         )
+
+    def test_from_edges(self):
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+
+        hv = functional.random_hv(4, 8, generator=generator)
+        edges = torch.empty(2, 3, 8)
+        edges[0, 0] = hv[0]
+        edges[1, 0] = hv[1]
+        edges[0, 1] = hv[0]
+        edges[1, 1] = hv[2]
+        edges[0, 2] = hv[1]
+        edges[1, 2] = hv[2]
+
+        G = structures.Graph.from_edges(edges)
+        neighbors = G.node_neighbors(hv[0])
+        neighbor_similarity = functional.cosine_similarity(neighbors, hv)
+
+        assert neighbor_similarity[0] < torch.tensor(0.5)
+        assert neighbor_similarity[1] > torch.tensor(0.5)
+        assert neighbor_similarity[2] > torch.tensor(0.5)
+        assert neighbor_similarity[3] < torch.tensor(0.5)

--- a/torchhd/tests/test_similarities.py
+++ b/torchhd/tests/test_similarities.py
@@ -15,7 +15,7 @@ seed = 2147483644
 class TestDotSimilarity:
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_shape(self, dtype):
-        if not supported_dtype(dtype):
+        if not supported_dtype(dtype) or dtype == torch.half:
             return
 
         generator = torch.Generator()
@@ -43,7 +43,7 @@ class TestDotSimilarity:
 
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_value(self, dtype):
-        if not supported_dtype(dtype):
+        if not supported_dtype(dtype) or dtype == torch.half:
             return
 
         generator = torch.Generator()
@@ -113,7 +113,7 @@ class TestDotSimilarity:
 
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_dtype(self, dtype):
-        if not supported_dtype(dtype):
+        if not supported_dtype(dtype) or dtype == torch.half:
             return
 
         generator = torch.Generator()
@@ -134,7 +134,7 @@ class TestDotSimilarity:
 
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_device(self, dtype):
-        if not supported_dtype(dtype):
+        if not supported_dtype(dtype) or dtype == torch.half:
             return
 
         generator = torch.Generator()
@@ -153,7 +153,7 @@ class TestDotSimilarity:
 class TestCosSimilarity:
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_shape(self, dtype):
-        if not supported_dtype(dtype):
+        if not supported_dtype(dtype) or dtype == torch.half:
             return
 
         generator = torch.Generator()
@@ -181,7 +181,7 @@ class TestCosSimilarity:
 
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_value(self, dtype):
-        if not supported_dtype(dtype):
+        if not supported_dtype(dtype) or dtype == torch.half:
             return
 
         generator = torch.Generator()
@@ -250,7 +250,7 @@ class TestCosSimilarity:
 
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_dtype(self, dtype):
-        if not supported_dtype(dtype):
+        if not supported_dtype(dtype) or dtype == torch.half:
             return
 
         generator = torch.Generator()
@@ -264,7 +264,7 @@ class TestCosSimilarity:
 
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_device(self, dtype):
-        if not supported_dtype(dtype):
+        if not supported_dtype(dtype) or dtype == torch.half:
             return
 
         generator = torch.Generator()


### PR DESCRIPTION
Added function that creates a hypervector containing the multiset of bound node hypervector pairs. Also added a convenient way to initialize a Graph structure using this method. This should make it easy to convert graphs from PyTorch Geometric into graph hypervectors.

Closes #9