### PR TITLE
Fix the nonlinear bug and add mnist example

### DIFF
--- a/examples/mnist_nonlinear.py
+++ b/examples/mnist_nonlinear.py
@@ -1,0 +1,77 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision
+from torchvision.datasets import MNIST
+
+# Note: this example requires the torchmetrics library: https://torchmetrics.readthedocs.io
+import torchmetrics
+from tqdm import tqdm
+
+import torchhd
+from torchhd import embeddings
+
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+print("Using {} device".format(device))
+
+DIMENSIONS = 10000
+IMG_SIZE = 28
+NUM_LEVELS = 1000
+BATCH_SIZE = 1  # for GPUs with enough memory we can process multiple images at ones
+
+transform = torchvision.transforms.ToTensor()
+
+train_ds = MNIST("../data", train=True, transform=transform, download=True)
+train_ld = torch.utils.data.DataLoader(train_ds, batch_size=BATCH_SIZE, shuffle=True)
+
+test_ds = MNIST("../data", train=False, transform=transform, download=True)
+test_ld = torch.utils.data.DataLoader(test_ds, batch_size=BATCH_SIZE, shuffle=False)
+
+class Model(nn.Module):
+    def __init__(self, num_classes, size):
+        super(Model, self).__init__()
+
+        self.flatten = torch.nn.Flatten()
+
+        self.nonlinear_projection = embeddings.Sinusoid(size * size, DIMENSIONS)
+
+        self.classify = nn.Linear(DIMENSIONS, num_classes, bias=False)
+        self.classify.weight.data.fill_(0.0)
+
+    def encode(self, x):
+        x = self.flatten(x)
+        sample_hv = self.nonlinear_projection(x)
+        return torchhd.hard_quantize(sample_hv)
+
+    def forward(self, x):
+        enc = self.encode(x)
+        logit = self.classify(enc)
+        return logit
+
+
+model = Model(len(train_ds.classes), IMG_SIZE)
+model = model.to(device)
+
+with torch.no_grad():
+    for samples, labels in tqdm(train_ld, desc="Training"):
+        samples = samples.to(device)
+        labels = labels.to(device)
+
+        samples_hv = model.encode(samples)
+        model.classify.weight[labels] += samples_hv
+
+    model.classify.weight[:] = F.normalize(model.classify.weight)
+
+accuracy = torchmetrics.Accuracy()
+
+
+with torch.no_grad():
+    for samples, labels in tqdm(test_ld, desc="Testing"):
+        samples = samples.to(device)
+
+        outputs = model(samples)
+        predictions = torch.argmax(outputs, dim=-1)
+        accuracy.update(predictions.cpu(), labels)
+
+print(f"Testing accuracy of {(accuracy.compute().item() * 100):.3f}%")

--- a/examples/mnist_nonlinear.py
+++ b/examples/mnist_nonlinear.py
@@ -1,3 +1,4 @@
+# This is an example of using nonlinear encoding on the MNIST dataset
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -17,7 +18,6 @@ print("Using {} device".format(device))
 
 DIMENSIONS = 10000
 IMG_SIZE = 28
-NUM_LEVELS = 1000
 BATCH_SIZE = 1  # for GPUs with enough memory we can process multiple images at ones
 
 transform = torchvision.transforms.ToTensor()

--- a/torchhd/embeddings.py
+++ b/torchhd/embeddings.py
@@ -409,6 +409,7 @@ class Sinusoid(nn.Module):
 
     def reset_parameters(self) -> None:
         nn.init.normal_(self.weight, 0, 1)
+        self.weight.data.copy_(F.normalize(self.weight.data))
         nn.init.uniform_(self.bias, 0, 2 * math.pi)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Add one more step in the nonlinear encoding: normalize the weight, which is similar to the random projection case.
To test it, I create a `mnist_nonlinear.py` in the examples.
Without this normalization, the accuracy of running `python mnist_nonlinear.py` is 10.75%.
After adding this normalization, the accuracy becomes 83.93%.

Another example that justify this change is in the `random_projection.py` example:
```
    def encode(self, x):
        enc = self.project(x)
        sample_hv = torch.cos(enc + self.bias) * torch.sin(enc)
        return torchhd.hard_quantize(sample_hv)
```
This encoding function is doing nothing but first a random projection and then passing through the nonlinear encoding.
Since in the random projection, the weight has been normalized; thus in the nonlinear encoding, the weight should also be normalized.

Please let me know if you have any questions or concerns.