### PR TITLE
Support for all VSA models in the embeddings module

### DIFF
--- a/docs/embeddings.rst
+++ b/docs/embeddings.rst
@@ -9,6 +9,7 @@ torchhd.embeddings
     :toctree: generated/
     :template: class.rst
 
+    Empty
     Identity
     Random
     Level

--- a/examples/emg_hand_gestures.py
+++ b/examples/emg_hand_gestures.py
@@ -66,7 +66,8 @@ def experiment(subjects=[0]):
     train_ld = data.DataLoader(train_ds, batch_size=BATCH_SIZE, shuffle=True)
     test_ld = data.DataLoader(test_ds, batch_size=BATCH_SIZE, shuffle=False)
 
-    model = Model(len(ds.classes), ds[0][0].size(-2), ds[0][0].size(-1))
+    num_classes = len(ds.classes)
+    model = Model(num_classes, ds[0][0].size(-2), ds[0][0].size(-1))
     model = model.to(device)
 
     with torch.no_grad():
@@ -79,7 +80,7 @@ def experiment(subjects=[0]):
 
         model.classify.weight[:] = F.normalize(model.classify.weight)
 
-    accuracy = torchmetrics.Accuracy()
+    accuracy = torchmetrics.Accuracy("multiclass", num_classes=num_classes)
 
     with torch.no_grad():
         for samples, labels in tqdm(test_ld, desc="Testing"):

--- a/examples/graphhd.py
+++ b/examples/graphhd.py
@@ -121,7 +121,7 @@ with torch.no_grad():
 
     model.classify.weight[:] = F.normalize(model.classify.weight)
 
-accuracy = torchmetrics.Accuracy()
+accuracy = torchmetrics.Accuracy("multiclass", num_classes=graphs.num_classes)
 
 with torch.no_grad():
     for samples in tqdm(test_ld, desc="Testing"):

--- a/examples/language_recognition.py
+++ b/examples/language_recognition.py
@@ -74,7 +74,8 @@ class Model(nn.Module):
         return logit
 
 
-model = Model(len(train_ds.classes), NUM_TOKENS)
+num_classes = len(train_ds.classes)
+model = Model(num_classes, NUM_TOKENS)
 model = model.to(device)
 
 with torch.no_grad():
@@ -87,7 +88,7 @@ with torch.no_grad():
 
     model.classify.weight[:] = F.normalize(model.classify.weight)
 
-accuracy = torchmetrics.Accuracy()
+accuracy = torchmetrics.Accuracy("multiclass", num_classes=num_classes)
 
 with torch.no_grad():
     for samples, labels in tqdm(test_ld, desc="Testing"):

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -53,7 +53,8 @@ class Model(nn.Module):
         return logit
 
 
-model = Model(len(train_ds.classes), IMG_SIZE)
+num_classes = len(train_ds.classes)
+model = Model(num_classes, IMG_SIZE)
 model = model.to(device)
 
 with torch.no_grad():
@@ -66,8 +67,7 @@ with torch.no_grad():
 
     model.classify.weight[:] = F.normalize(model.classify.weight)
 
-accuracy = torchmetrics.Accuracy()
-
+accuracy = torchmetrics.Accuracy("multiclass", num_classes=num_classes)
 
 with torch.no_grad():
     for samples, labels in tqdm(test_ld, desc="Testing"):

--- a/examples/mnist_hugging_face.py
+++ b/examples/mnist_hugging_face.py
@@ -6,6 +6,7 @@ from torchvision.datasets import MNIST
 
 # Note: this example requires the torchmetrics library: https://torchmetrics.readthedocs.io
 import torchmetrics
+
 # Note: this example requires the accelerate library: https://github.com/huggingface/accelerate
 from accelerate import Accelerator
 from tqdm import tqdm

--- a/examples/mnist_hugging_face.py
+++ b/examples/mnist_hugging_face.py
@@ -6,8 +6,9 @@ from torchvision.datasets import MNIST
 
 # Note: this example requires the torchmetrics library: https://torchmetrics.readthedocs.io
 import torchmetrics
-from tqdm import tqdm
+# Note: this example requires the accelerate library: https://github.com/huggingface/accelerate
 from accelerate import Accelerator
+from tqdm import tqdm
 
 import torchhd
 from torchhd import embeddings
@@ -54,7 +55,8 @@ class Model(nn.Module):
         return logit
 
 
-model = Model(len(train_ds.classes), IMG_SIZE)
+num_classes = len(train_ds.classes)
+model = Model(num_classes, IMG_SIZE)
 model.to(device)
 
 model, train_ld, test_ld = accelerator.prepare(model, train_ld, test_ld)
@@ -69,8 +71,7 @@ with torch.no_grad():
 
     model.classify.weight[:] = F.normalize(model.classify.weight)
 
-accuracy = torchmetrics.Accuracy()
-
+accuracy = torchmetrics.Accuracy("multiclass", num_classes=num_classes)
 
 with torch.no_grad():
     for samples, labels in tqdm(test_ld, desc="Testing"):

--- a/examples/mnist_nonlinear.py
+++ b/examples/mnist_nonlinear.py
@@ -51,6 +51,7 @@ class Model(nn.Module):
         return logit
 
 
+num_classes = len(train_ds.classes)
 model = Model(len(train_ds.classes), IMG_SIZE)
 model = model.to(device)
 
@@ -64,8 +65,7 @@ with torch.no_grad():
 
     model.classify.weight[:] = F.normalize(model.classify.weight)
 
-accuracy = torchmetrics.Accuracy()
-
+accuracy = torchmetrics.Accuracy("multiclass", num_classes=num_classes)
 
 with torch.no_grad():
     for samples, labels in tqdm(test_ld, desc="Testing"):

--- a/examples/mnist_nonlinear.py
+++ b/examples/mnist_nonlinear.py
@@ -28,6 +28,7 @@ train_ld = torch.utils.data.DataLoader(train_ds, batch_size=BATCH_SIZE, shuffle=
 test_ds = MNIST("../data", train=False, transform=transform, download=True)
 test_ld = torch.utils.data.DataLoader(test_ds, batch_size=BATCH_SIZE, shuffle=False)
 
+
 class Model(nn.Module):
     def __init__(self, num_classes, size):
         super(Model, self).__init__()

--- a/examples/mnist_torch_lightning.py
+++ b/examples/mnist_torch_lightning.py
@@ -6,8 +6,9 @@ from torchvision.datasets import MNIST
 
 # Note: this example requires the torchmetrics library: https://torchmetrics.readthedocs.io
 import torchmetrics
-from tqdm import tqdm
+# Note: this example requires the pytorch-lightning library: https://www.pytorchlightning.ai
 import pytorch_lightning as pl
+from tqdm import tqdm
 
 import torchhd
 from torchhd import embeddings
@@ -60,7 +61,8 @@ class Model(pl.LightningModule):
         return
 
 
-model = Model(len(train_ds.classes), IMG_SIZE)
+num_classes = len(train_ds.classes)
+model = Model(num_classes, IMG_SIZE)
 trainer = pl.Trainer(
     accelerator="cpu",
     devices=1,
@@ -77,8 +79,7 @@ with torch.no_grad():
 
     model.classify.weight[:] = F.normalize(model.classify.weight)
 
-accuracy = torchmetrics.Accuracy()
-
+accuracy = torchmetrics.Accuracy("multiclass", num_classes=num_classes)
 
 with torch.no_grad():
     for samples, labels in tqdm(test_ld, desc="Testing"):

--- a/examples/mnist_torch_lightning.py
+++ b/examples/mnist_torch_lightning.py
@@ -6,6 +6,7 @@ from torchvision.datasets import MNIST
 
 # Note: this example requires the torchmetrics library: https://torchmetrics.readthedocs.io
 import torchmetrics
+
 # Note: this example requires the pytorch-lightning library: https://www.pytorchlightning.ai
 import pytorch_lightning as pl
 from tqdm import tqdm

--- a/examples/random_projection.py
+++ b/examples/random_projection.py
@@ -58,16 +58,13 @@ class Model(nn.Module):
         self.target = embeddings.Level(
             500, DIMENSIONS, low=MIN_TEMPERATURE, high=MAX_TEMPERATURE
         )
-        self.project = embeddings.Projection(size, DIMENSIONS)
-        self.bias = nn.parameter.Parameter(torch.empty(DIMENSIONS), requires_grad=False)
-        self.bias.data.uniform_(0, 2 * math.pi)
+        self.project = embeddings.Sinusoid(size, DIMENSIONS)
 
         self.regression = nn.Linear(DIMENSIONS, num_classes, bias=False)
         self.regression.weight.data.fill_(0.0)
 
     def encode(self, x):
-        enc = self.project(x)
-        sample_hv = torch.cos(enc + self.bias) * torch.sin(enc)
+        sample_hv = self.project(x)
         return torchhd.hard_quantize(sample_hv)
 
     def forward(self, x):

--- a/examples/reghd.py
+++ b/examples/reghd.py
@@ -18,7 +18,7 @@ print("Using {} device".format(device))
 DIMENSIONS = 10000  # number of hypervector dimensions
 NUM_FEATURES = 5  # number of features in dataset
 
-ds = AirfoilSelfNoise("../data", download=False)
+ds = AirfoilSelfNoise("../data", download=True)
 
 # Get necessary statistics for data and target transform
 STD_DEVS = ds.data.std(0)
@@ -57,14 +57,10 @@ class SingleModel(nn.Module):
 
         self.lr = 0.00001
         self.M = torch.zeros(1, DIMENSIONS)
-        self.project = embeddings.Projection(size, DIMENSIONS)
-        self.project.weight.data.normal_(0, 1)
-        self.bias = nn.parameter.Parameter(torch.empty(DIMENSIONS), requires_grad=False)
-        self.bias.data.uniform_(0, 2 * math.pi)
+        self.project = embeddings.Sinusoid(size, DIMENSIONS)
 
     def encode(self, x):
-        enc = self.project(x)
-        sample_hv = torch.cos(enc + self.bias) * torch.sin(enc)
+        sample_hv = self.project(x)
         return torchhd.hard_quantize(sample_hv)
 
     def model_update(self, x, y):

--- a/examples/voicehd.py
+++ b/examples/voicehd.py
@@ -43,10 +43,10 @@ train_ds = ISOLET("../data", train=True, download=True)
 train_ld = torch.utils.data.DataLoader(train_ds, batch_size=BATCH_SIZE, shuffle=True)
 
 test_ds = ISOLET("../data", train=False, download=True)
-
 test_ld = torch.utils.data.DataLoader(test_ds, batch_size=BATCH_SIZE, shuffle=False)
 
-model = Model(len(train_ds.classes), train_ds[0][0].size(-1))
+num_classes = len(train_ds.classes)
+model = Model(num_classes, train_ds[0][0].size(-1))
 model = model.to(device)
 
 with torch.no_grad():
@@ -59,7 +59,7 @@ with torch.no_grad():
 
     model.classify.weight[:] = F.normalize(model.classify.weight)
 
-accuracy = torchmetrics.Accuracy()
+accuracy = torchmetrics.Accuracy("multiclass", num_classes=num_classes)
 
 with torch.no_grad():
     for samples, labels in tqdm(test_ld, desc="Testing"):

--- a/torchhd/bsc.py
+++ b/torchhd/bsc.py
@@ -70,6 +70,8 @@ class BSC(VSA_Model):
                     [0, 1, 1, 0, 1, 1]])
 
         """
+        if dtype is None:
+            dtype = torch.bool
 
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
@@ -116,6 +118,8 @@ class BSC(VSA_Model):
                     [0, 0, 0, 0, 0, 0]])
 
         """
+        if dtype is None:
+            dtype = torch.bool
 
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
@@ -174,6 +178,9 @@ class BSC(VSA_Model):
                     [0, 1, 1, 0, 0, 0]])
 
         """
+        if dtype is None:
+            dtype = torch.bool
+
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
             options = ", ".join([str(x) for x in cls.supported_dtypes])

--- a/torchhd/embeddings.py
+++ b/torchhd/embeddings.py
@@ -516,7 +516,7 @@ class Thermometer(nn.Embedding):
         requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: ``False``.
 
     Values outside the interval between low and high are clipped to the closed bound.
-    
+
     Examples::
 
         >>> emb = embeddings.Thermometer(4, 6)
@@ -731,7 +731,9 @@ class Circular(nn.Embedding):
             self.weight.copy_(embeddings)
 
     def forward(self, input: Tensor) -> Tensor:
-        mapped = functional.map_range(input, self.phase, self.period, 0, self.num_embeddings)
+        mapped = functional.map_range(
+            input, self.phase, self.period, 0, self.num_embeddings
+        )
         index = mapped.round().long() % self.num_embeddings
         return super().forward(index).as_subclass(self.vsa_model)
 

--- a/torchhd/embeddings.py
+++ b/torchhd/embeddings.py
@@ -30,8 +30,8 @@ class Empty(nn.Embedding):
     Args:
         num_embeddings (int): the number of hypervectors to generate.
         embedding_dim (int): the dimensionality of the hypervectors.
-        model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
-        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` depends on VSA_Model.
+        vsa_model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
+        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` uses default of VSA_Model.
         device (``torch.device``, optional):  the desired device of returned tensor. Default: if ``None``, uses the current device for the default tensor type (see torch.set_default_tensor_type()). ``device`` will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types.
         requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: ``False``.
 
@@ -113,7 +113,7 @@ class Empty(nn.Embedding):
         # prevent errors when instantiating a non-float embedding
         self.weight = Parameter(embeddings, requires_grad=requires_grad)
 
-        self._fill_padding_idx_with_zero()
+        # we don't need to set the padding to empty because it is already empty.
 
     def reset_parameters(self) -> None:
         factory_kwargs = {"device": self.weight.device, "dtype": self.weight.dtype}
@@ -127,8 +127,6 @@ class Empty(nn.Embedding):
             )
             self.weight.copy_(embeddings)
 
-        self._fill_padding_idx_with_zero()
-
     def forward(self, input: Tensor) -> Tensor:
         return super().forward(input).as_subclass(self.vsa_model)
 
@@ -141,8 +139,8 @@ class Identity(nn.Embedding):
     Args:
         num_embeddings (int): the number of hypervectors to generate.
         embedding_dim (int): the dimensionality of the hypervectors.
-        model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
-        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` depends on VSA_Model.
+        vsa_model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
+        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` uses default of VSA_Model.
         device (``torch.device``, optional):  the desired device of returned tensor. Default: if ``None``, uses the current device for the default tensor type (see torch.set_default_tensor_type()). ``device`` will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types.
         requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: ``False``.
 
@@ -224,7 +222,7 @@ class Identity(nn.Embedding):
         # prevent errors when instantiating a non-float embedding
         self.weight = Parameter(embeddings, requires_grad=requires_grad)
 
-        self._fill_padding_idx_with_zero()
+        self._fill_padding_idx_with_empty()
 
     def reset_parameters(self) -> None:
         factory_kwargs = {"device": self.weight.device, "dtype": self.weight.dtype}
@@ -238,7 +236,17 @@ class Identity(nn.Embedding):
             )
             self.weight.copy_(embeddings)
 
-        self._fill_padding_idx_with_zero()
+        self._fill_padding_idx_with_empty()
+
+    def _fill_padding_idx_with_empty(self) -> None:
+        factory_kwargs = {"device": self.weight.device, "dtype": self.weight.dtype}
+
+        if self.padding_idx is not None:
+            with torch.no_grad():
+                empty = functional.empty_hv(
+                    1, self.embedding_dim, self.vsa_model, **factory_kwargs
+                )
+                self.weight[self.padding_idx].copy_(empty.squeeze(0))
 
     def forward(self, input: Tensor) -> Tensor:
         return super().forward(input).as_subclass(self.vsa_model)
@@ -252,8 +260,8 @@ class Random(nn.Embedding):
     Args:
         num_embeddings (int): the number of hypervectors to generate.
         embedding_dim (int): the dimensionality of the hypervectors.
-        model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
-        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` depends on VSA_Model.
+        vsa_model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
+        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` uses default of ``vsa_model``.
         device (``torch.device``, optional):  the desired device of returned tensor. Default: if ``None``, uses the current device for the default tensor type (see torch.set_default_tensor_type()). ``device`` will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types.
         requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: ``False``.
 
@@ -335,7 +343,7 @@ class Random(nn.Embedding):
         # prevent errors when instantiating a non-float embedding
         self.weight = Parameter(embeddings, requires_grad=requires_grad)
 
-        self._fill_padding_idx_with_zero()
+        self._fill_padding_idx_with_empty()
 
     def reset_parameters(self) -> None:
         factory_kwargs = {"device": self.weight.device, "dtype": self.weight.dtype}
@@ -349,124 +357,147 @@ class Random(nn.Embedding):
             )
             self.weight.copy_(embeddings)
 
-        self._fill_padding_idx_with_zero()
+        self._fill_padding_idx_with_empty()
+
+    def _fill_padding_idx_with_empty(self) -> None:
+        factory_kwargs = {"device": self.weight.device, "dtype": self.weight.dtype}
+
+        if self.padding_idx is not None:
+            with torch.no_grad():
+                empty = functional.empty_hv(
+                    1, self.embedding_dim, self.vsa_model, **factory_kwargs
+                )
+                self.weight[self.padding_idx].copy_(empty.squeeze(0))
 
     def forward(self, input: Tensor) -> Tensor:
         return super().forward(input).as_subclass(self.vsa_model)
 
 
-class Level(nn.Module):
+class Level(nn.Embedding):
     """Embedding wrapper around :func:`~torchhd.level_hv`.
 
+    Class inherits from `Embedding <https://pytorch.org/docs/stable/generated/torch.nn.Embedding.html>`_ and supports the same keyword arguments.
+
     Args:
+        num_embeddings (int): the number of hypervectors to generate.
         embedding_dim (int): the dimensionality of the hypervectors.
+        vsa_model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
         low (float, optional): The lower bound of the real number range that the levels represent. Default: ``0.0``
         high (float, optional): The upper bound of the real number range that the levels represent. Default: ``1.0``
-        num_ortho (int): the number of quasi-orthogonal hypervectors to generate over the span from ``low`` to ``high``. Default: ``2.0``
-        randomness (float, optional): r-value to interpolate between level at ``0.0`` and random-hypervectors at ``1.0``. Default: ``0.0``
-        requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: ``False``
+        randomness (float, optional): r-value to interpolate between level-hypervectors at ``0.0`` and random-hypervectors at ``1.0``. Default: ``0.0``.
+        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` uses default of ``vsa_model``.
+        device (``torch.device``, optional):  the desired device of returned tensor. Default: if ``None``, uses the current device for the default tensor type (see torch.set_default_tensor_type()). ``device`` will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types.
+        requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: ``False``.
 
-    For example, ``num_ortho=2.0`` means that the ``low`` and ``high`` values have exactly one random hypervector each and in between is an interpolation of those two.
-    And with ``num_ortho=3.0`` there is one additional random hypervector that represents halfway between ``low`` and ``high``.
+    Values outside the interval between low and high are clipped to the closed bound.
 
     Examples::
 
-        >>> emb = embeddings.Level(5, 10, low=-1, high=2)
-        >>> x = torch.FloatTensor([0.3, 1.9, -0.8])
+        >>> emb = embeddings.Level(4, 6)
+        >>> x = torch.rand(4)
+        >>> x
+        tensor([0.6444, 0.9286, 0.9225, 0.3675])
         >>> emb(x)
-        tensor([[-1.,  1.,  1., -1., -1., -1., -1.,  1.,  1.,  1.],
-                [-1.,  1., -1.,  1., -1., -1., -1.,  1.,  1., -1.],
-                [ 1., -1.,  1., -1., -1., -1.,  1.,  1., -1.,  1.]])
+        MAP([[ 1.,  1.,  1., -1.,  1.,  1.],
+             [ 1.,  1., -1.,  1.,  1.,  1.],
+             [ 1.,  1., -1.,  1.,  1.,  1.],
+             [ 1.,  1.,  1., -1., -1.,  1.]])
+
+        >>> emb = embeddings.Level(4, 6, torchhd.BSC)
+        >>> x = torch.rand(4)
+        >>> x
+        tensor([0.1825, 0.1541, 0.4435, 0.1512])
+        >>> emb(x)
+        BSC([[False,  True, False, False, False, False],
+             [False,  True, False, False, False, False],
+             [False,  True, False, False, False, False],
+             [False,  True, False, False, False, False]])
 
     """
 
     __constants__ = [
-        "num_ortho",
         "num_embeddings",
         "embedding_dim",
+        "vsa_model",
         "low",
         "high",
-        "vsa_model",
+        "randomness",
+        "padding_idx",
+        "max_norm",
+        "norm_type",
+        "scale_grad_by_freq",
+        "sparse",
     ]
 
-    num_ortho: float
-    num_embeddings: int
-    embedding_dim: int
     low: float
     high: float
+    randomness: float
     vsa_model: Type[VSA_Model]
-    threshold: Tensor
-    weight: Tensor
 
     def __init__(
         self,
+        num_embeddings: int,
         embedding_dim: int,
+        vsa_model: Type[VSA_Model] = MAP,
         low: float = 0.0,
         high: float = 1.0,
-        num_ortho: float = 2.0,
-        vsa_model: Type[VSA_Model] = MAP,
+        randomness: float = 0.0,
         requires_grad: bool = False,
+        max_norm: Optional[float] = None,
+        norm_type: float = 2.0,
+        scale_grad_by_freq: bool = False,
+        sparse: bool = False,
         device=None,
         dtype=None,
     ) -> None:
 
         factory_kwargs = {"device": device, "dtype": dtype}
-        super(Level, self).__init__()
+        # Have to call Module init explicitly in order not to use the Embedding init
+        nn.Module.__init__(self)
 
-        assert num_ortho > 1.0, "num_ortho must be more than 1.0"
-
-        self.num_ortho = num_ortho
-        self.num_embeddings = int(math.ceil(num_ortho))
+        self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
         self.vsa_model = vsa_model
         self.low = low
         self.high = high
+        self.randomness = randomness
 
-        embeddings = functional.random_hv(
-            self.num_embeddings, self.embedding_dim, vsa_model, **factory_kwargs
-        )
-        self.weight = Parameter(embeddings, requires_grad=requires_grad)
+        self.padding_idx = None
+        self.max_norm = max_norm
+        self.norm_type = norm_type
+        self.scale_grad_by_freq = scale_grad_by_freq
+        self.sparse = sparse
 
-        threshold = torch.rand(
-            self.num_embeddings - 1,
+        embeddings = functional.level_hv(
+            num_embeddings,
             embedding_dim,
-            dtype=torch.float,
-            device=device,
+            vsa_model,
+            randomness=randomness,
+            **factory_kwargs
         )
-        self.register_buffer("threshold", threshold)
+        # Have to provide requires grad at the creation of the parameters to
+        # prevent errors when instantiating a non-float embedding
+        self.weight = Parameter(embeddings, requires_grad=requires_grad)
 
     def reset_parameters(self) -> None:
         factory_kwargs = {"device": self.weight.device, "dtype": self.weight.dtype}
 
         with torch.no_grad():
-            self.threshold.uniform_()
-            embeddings = functional.random_hv(
+            embeddings = functional.level_hv(
                 self.num_embeddings,
                 self.embedding_dim,
                 self.vsa_model,
+                randomness=self.randomness,
                 **factory_kwargs
             )
             self.weight.copy_(embeddings)
 
     def forward(self, input: Tensor) -> Tensor:
-        shape = input.shape
-
-        span = functional.map_range(
-            input, self.low, self.high, 0, self.num_embeddings - 1
+        index = functional.value_to_index(
+            input, self.low, self.high, self.num_embeddings
         )
-        span = span.clamp(min=0, max=self.num_embeddings - 1)
-        span_idx = span.floor().clamp_max(self.num_embeddings - 2)
-
-        tau = (span - span_idx).ravel().unsqueeze(-1)
-        span_idx = span_idx.long().ravel()
-
-        span_start = self.weight.index_select(0, span_idx)
-        span_end = self.weight.index_select(0, span_idx + 1)
-        threshold = self.threshold.index_select(0, span_idx)
-
-        hv = torch.where(threshold < tau, span_start, span_end)
-        hv = hv.view(*shape, -1)
-        return hv.as_subclass(self.vsa_model)
+        index = index.clamp(min=0, max=self.num_embeddings - 1)
+        return super().forward(index).as_subclass(self.vsa_model)
 
 
 class Thermometer(nn.Embedding):
@@ -477,56 +508,113 @@ class Thermometer(nn.Embedding):
     Args:
         num_embeddings (int): the number of hypervectors to generate.
         embedding_dim (int): the dimensionality of the hypervectors.
+        vsa_model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
         low (float, optional): The lower bound of the real number range that the levels represent. Default: ``0.0``
         high (float, optional): The upper bound of the real number range that the levels represent. Default: ``1.0``
+        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` uses default of VSA_Model.
+        device (``torch.device``, optional):  the desired device of returned tensor. Default: if ``None``, uses the current device for the default tensor type (see torch.set_default_tensor_type()). ``device`` will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types.
         requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: ``False``.
 
+    Values outside the interval between low and high are clipped to the closed bound.
+    
     Examples::
 
-        >>> emb = embeddings.Thermometer(11, 10, low=-1, high=2)
-        >>> x = torch.FloatTensor([0.3, 1.9, -0.8])
+        >>> emb = embeddings.Thermometer(4, 6)
+        >>> x = torch.rand(4)
+        >>> x
+        tensor([0.5295, 0.0618, 0.0675, 0.1750])
         >>> emb(x)
-        tensor([[ 1.,  1.,  1.,  1., -1., -1., -1., -1., -1., -1.],
-                [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
-                [ 1., -1., -1., -1., -1., -1., -1., -1., -1., -1.]])
+        MAP([[ 1.,  1.,  1.,  1., -1., -1.],
+             [-1., -1., -1., -1., -1., -1.],
+             [-1., -1., -1., -1., -1., -1.],
+             [ 1.,  1., -1., -1., -1., -1.]])
+
+        >>> emb = embeddings.Thermometer(4, 6, torchhd.FHRR)
+        >>> x = torch.rand(4)
+        >>> x
+        tensor([0.2668, 0.7668, 0.8083, 0.6247])
+        >>> emb(x)
+        FHRR([[ 1.+0.j,  1.+0.j, -1.+0.j, -1.+0.j, -1.+0.j, -1.+0.j],
+              [ 1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j, -1.+0.j, -1.+0.j],
+              [ 1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j, -1.+0.j, -1.+0.j],
+              [ 1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j, -1.+0.j, -1.+0.j]])
 
     """
 
+    __constants__ = [
+        "num_embeddings",
+        "embedding_dim",
+        "vsa_model",
+        "low",
+        "high",
+        "padding_idx",
+        "max_norm",
+        "norm_type",
+        "scale_grad_by_freq",
+        "sparse",
+    ]
+
+    low: float
+    high: float
+    vsa_model: Type[VSA_Model]
+
     def __init__(
         self,
-        num_embeddings,
-        embedding_dim,
-        low=0.0,
-        high=1.0,
-        requires_grad=False,
-        **kwargs
-    ):
-        self.low_value = low
-        self.high_value = high
+        num_embeddings: int,
+        embedding_dim: int,
+        vsa_model: Type[VSA_Model] = MAP,
+        low: float = 0.0,
+        high: float = 1.0,
+        requires_grad: bool = False,
+        max_norm: Optional[float] = None,
+        norm_type: float = 2.0,
+        scale_grad_by_freq: bool = False,
+        sparse: bool = False,
+        device=None,
+        dtype=None,
+    ) -> None:
 
-        super(Thermometer, self).__init__(num_embeddings, embedding_dim, **kwargs)
-        self.weight.requires_grad = requires_grad
+        factory_kwargs = {"device": device, "dtype": dtype}
+        # Have to call Module init explicitly in order not to use the Embedding init
+        nn.Module.__init__(self)
 
-    def reset_parameters(self):
-        factory_kwargs = {
-            "device": self.weight.data.device,
-            "dtype": self.weight.data.dtype,
-        }
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
+        self.vsa_model = vsa_model
+        self.low = low
+        self.high = high
 
-        self.weight.data.copy_(
-            functional.thermometer_hv(
-                self.num_embeddings, self.embedding_dim, **factory_kwargs
-            )
+        self.padding_idx = None
+        self.max_norm = max_norm
+        self.norm_type = norm_type
+        self.scale_grad_by_freq = scale_grad_by_freq
+        self.sparse = sparse
+
+        embeddings = functional.thermometer_hv(
+            num_embeddings, embedding_dim, vsa_model, **factory_kwargs
         )
+        # Have to provide requires grad at the creation of the parameters to
+        # prevent errors when instantiating a non-float embedding
+        self.weight = Parameter(embeddings, requires_grad=requires_grad)
 
-        self._fill_padding_idx_with_zero()
+    def reset_parameters(self) -> None:
+        factory_kwargs = {"device": self.weight.device, "dtype": self.weight.dtype}
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        indices = functional.value_to_index(
-            input, self.low_value, self.high_value, self.num_embeddings
-        ).clamp(0, self.num_embeddings - 1)
+        with torch.no_grad():
+            embeddings = functional.thermometer_hv(
+                self.num_embeddings,
+                self.embedding_dim,
+                self.vsa_model,
+                **factory_kwargs
+            )
+            self.weight.copy_(embeddings)
 
-        return super(Thermometer, self).forward(indices).as_subclass(MAP)
+    def forward(self, input: Tensor) -> Tensor:
+        index = functional.value_to_index(
+            input, self.low, self.high, self.num_embeddings
+        )
+        index = index.clamp(min=0, max=self.num_embeddings - 1)
+        return super().forward(index).as_subclass(self.vsa_model)
 
 
 class Circular(nn.Embedding):
@@ -537,62 +625,115 @@ class Circular(nn.Embedding):
     Args:
         num_embeddings (int): the number of hypervectors to generate.
         embedding_dim (int): the dimensionality of the hypervectors.
-        low (float, optional): The lower bound of the real number range that the circular levels represent. Default: ``0.0``
-        high (float, optional): The upper bound of the real number range that the circular levels represent. Default: ``2 * pi``
-        randomness (float, optional): r-value to interpolate between circular at ``0.0`` and random-hypervectors at ``1.0``. Default: ``0.0``.
+        vsa_model: (``Type[VSA_Model]``, optional): specifies the hypervector type to be instantiated. Default: ``torchhd.MAP``.
+        phase (float, optional): The zero offset of the real number periodic interval that the circular levels represent. Default: ``0.0``
+        period (float, optional): The period of the real number periodic interval that the circular levels represent. Default: ``2 * pi``
+        randomness (float, optional): r-value to interpolate between circular-hypervectors at ``0.0`` and random-hypervectors at ``1.0``. Default: ``0.0``.
+        dtype (``torch.dtype``, optional): the desired data type of returned tensor. Default: if ``None`` uses default of ``vsa_model``.
+        device (``torch.device``, optional):  the desired device of returned tensor. Default: if ``None``, uses the current device for the default tensor type (see torch.set_default_tensor_type()). ``device`` will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types.
         requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: ``False``.
 
     Examples::
 
-        >>> emb = embeddings.Circular(5, 10)
-        >>> x = torch.FloatTensor([0.0, 3.14, 6.28])
-        >>> emb(x)
-        tensor([[ 1., -1.,  1., -1.,  1.,  1.,  1.,  1., -1.,  1.],
-                [ 1., -1., -1.,  1.,  1.,  1.,  1., -1., -1., -1.],
-                [ 1., -1., -1., -1.,  1.,  1.,  1.,  1.,  1., -1.]])
+        >>> emb = embeddings.Circular(4, 6)
+        >>> angle = torch.tensor([0.0, 3.141, 6.282, 9.423])
+        >>> emb(angle)
+        MAP([[-1., -1., -1., -1., -1.,  1.],
+             [-1., -1.,  1.,  1., -1., -1.],
+             [-1., -1., -1., -1., -1.,  1.],
+             [-1., -1.,  1.,  1., -1., -1.]])
+
+        >>> emb = embeddings.Circular(4, 6, torchhd.BSC)
+        >>> angle = torch.tensor([0.0, 3.141, 6.282, 9.423])
+        >>> emb(angle)
+        BSC([[False,  True, False, False,  True,  True],
+             [False, False, False, False, False,  True],
+             [False,  True, False, False,  True,  True],
+             [False, False, False, False, False,  True]])
 
     """
 
+    __constants__ = [
+        "num_embeddings",
+        "embedding_dim",
+        "vsa_model",
+        "phase",
+        "period",
+        "randomness",
+        "padding_idx",
+        "max_norm",
+        "norm_type",
+        "scale_grad_by_freq",
+        "sparse",
+    ]
+
+    phase: float
+    period: float
+    randomness: float
+    vsa_model: Type[VSA_Model]
+
     def __init__(
         self,
-        num_embeddings,
-        embedding_dim,
-        low=0.0,
-        high=2 * math.pi,
-        randomness=0.0,
-        requires_grad=False,
-        **kwargs
-    ):
-        self.low_value = low
-        self.high_value = high
+        num_embeddings: int,
+        embedding_dim: int,
+        vsa_model: Type[VSA_Model] = MAP,
+        phase: float = 0.0,
+        period: float = 2 * math.pi,
+        randomness: float = 0.0,
+        requires_grad: bool = False,
+        max_norm: Optional[float] = None,
+        norm_type: float = 2.0,
+        scale_grad_by_freq: bool = False,
+        sparse: bool = False,
+        device=None,
+        dtype=None,
+    ) -> None:
+
+        factory_kwargs = {"device": device, "dtype": dtype}
+        # Have to call Module init explicitly in order not to use the Embedding init
+        nn.Module.__init__(self)
+
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
+        self.vsa_model = vsa_model
+        self.phase = phase
+        self.period = period
         self.randomness = randomness
 
-        super(Circular, self).__init__(num_embeddings, embedding_dim, **kwargs)
-        self.weight.requires_grad = requires_grad
+        self.padding_idx = None
+        self.max_norm = max_norm
+        self.norm_type = norm_type
+        self.scale_grad_by_freq = scale_grad_by_freq
+        self.sparse = sparse
 
-    def reset_parameters(self):
-        factory_kwargs = {
-            "device": self.weight.data.device,
-            "dtype": self.weight.data.dtype,
-        }
+        embeddings = functional.circular_hv(
+            num_embeddings,
+            embedding_dim,
+            vsa_model,
+            randomness=randomness,
+            **factory_kwargs
+        )
+        # Have to provide requires grad at the creation of the parameters to
+        # prevent errors when instantiating a non-float embedding
+        self.weight = Parameter(embeddings, requires_grad=requires_grad)
 
-        self.weight.data.copy_(
-            functional.circular_hv(
+    def reset_parameters(self) -> None:
+        factory_kwargs = {"device": self.weight.device, "dtype": self.weight.dtype}
+
+        with torch.no_grad():
+            embeddings = functional.circular_hv(
                 self.num_embeddings,
                 self.embedding_dim,
+                self.vsa_model,
                 randomness=self.randomness,
                 **factory_kwargs
             )
-        )
+            self.weight.copy_(embeddings)
 
-        self._fill_padding_idx_with_zero()
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        indices = functional.value_to_index(
-            input, self.low_value, self.high_value, self.num_embeddings
-        ).remainder(self.num_embeddings - 1)
-
-        return super(Circular, self).forward(indices).as_subclass(MAP)
+    def forward(self, input: Tensor) -> Tensor:
+        mapped = functional.map_range(input, self.phase, self.period, 0, self.num_embeddings)
+        index = mapped.round().long() % self.num_embeddings
+        return super().forward(index).as_subclass(self.vsa_model)
 
 
 class Projection(nn.Module):
@@ -655,7 +796,7 @@ class Sinusoid(nn.Module):
     r"""Embedding using a nonlinear random projection
 
     Implemented based on `Scalable Edge-Based Hyperdimensional Learning System with Brain-Like Neural Adaptation <https://dl.acm.org/doi/abs/10.1145/3458817.3480958>`_.
-    It computes :math:`\cos(x \Phi^{\mathsf{T}} + b) \odot \sin(x \Phi^{\mathsf{T}})` where :math:`\Phi \in \mathbb{R}^{d \times m}` is a matrix whose elements are sampled at random from a standard normal distribution and :math:`b \in \mathbb{R}^{d}` is a vectors whose elements are sampled uniformly at random between 0 and :math:`2\pi`.
+    It computes :math:`\cos(x \Phi^{\mathsf{T}} + b) \odot \sin(x \Phi^{\mathsf{T}})` where :math:`\Phi \in \mathbb{R}^{d \times m}` is a matrix whose rows are uniformly sampled at random from the surface of an :math:`d`-dimensional unit sphere and :math:`b \in \mathbb{R}^{d}` is a vectors whose elements are sampled uniformly at random between 0 and :math:`2\pi`.
 
     Args:
         in_features (int): the dimensionality of the input feature vector.

--- a/torchhd/fhrr.py
+++ b/torchhd/fhrr.py
@@ -57,7 +57,7 @@ class FHRR(VSA_Model):
         """
         if dtype is None:
             dtype = torch.complex64
-            
+
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
             options = ", ".join([str(x) for x in cls.supported_dtypes])
@@ -110,7 +110,7 @@ class FHRR(VSA_Model):
         """
         if dtype is None:
             dtype = torch.complex64
-            
+
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
             options = ", ".join([str(x) for x in cls.supported_dtypes])
@@ -164,7 +164,7 @@ class FHRR(VSA_Model):
         """
         if dtype is None:
             dtype = torch.complex64
-            
+
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
             options = ", ".join([str(x) for x in cls.supported_dtypes])

--- a/torchhd/fhrr.py
+++ b/torchhd/fhrr.py
@@ -55,6 +55,9 @@ class FHRR(VSA_Model):
                     [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]],
                    dtype=torch.complex128)
         """
+        if dtype is None:
+            dtype = torch.complex64
+            
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
             options = ", ".join([str(x) for x in cls.supported_dtypes])
@@ -105,6 +108,9 @@ class FHRR(VSA_Model):
 
 
         """
+        if dtype is None:
+            dtype = torch.complex64
+            
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
             options = ", ".join([str(x) for x in cls.supported_dtypes])
@@ -156,6 +162,9 @@ class FHRR(VSA_Model):
                     dtype=torch.complex128)
 
         """
+        if dtype is None:
+            dtype = torch.complex64
+            
         if dtype not in cls.supported_dtypes:
             name = cls.__name__
             options = ", ".join([str(x) for x in cls.supported_dtypes])


### PR DESCRIPTION
With this update users can specify which VSA models they want to use when using the embeddings classes, like is already possible on the functional equivalent. With the exception of the two projection classes `Projection` and `Sinusoids`.