### PR TITLE
Fix dtype validation error in the Fractional Power Encoding

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,9 @@
 
 ## Description
 <!--- Describe your changes in detail -->
-
 <!-- Link the issue (if any) that will be resolved by the changes -->
+
+
 
 ## Checklist
 - [ ] I added/updated documentation for the changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!--- Provide a short summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+<!-- Link the issue (if any) that will be resolved by the changes -->
+
+## Checklist
+- [ ] I added/updated documentation for the changes.
+- [ ] I have thoroughly tested the changes.

--- a/torchhd/embeddings.py
+++ b/torchhd/embeddings.py
@@ -1032,9 +1032,6 @@ class FractionalPower(nn.Module):
 
         self.vsa_tensor = functional.get_vsa_tensor_class(vsa)
 
-        if dtype not in self.vsa_tensor.supported_dtypes:
-            raise ValueError(f"dtype {dtype} not supported by {vsa}")
-
         # If the distribution is a string use the presets in predefined_kernels
         if isinstance(distribution, str):
             try:

--- a/torchhd/embeddings.py
+++ b/torchhd/embeddings.py
@@ -1034,9 +1034,9 @@ class FractionalPower(nn.Module):
         # If a specific dtype is specified make sure it is supported by the VSA model
         if dtype != None and dtype not in self.vsa_tensor.supported_dtypes:
             raise ValueError(f"dtype {dtype} not supported by {vsa}")
-        
+
         # The internal weights/phases are stored as floats even if the output is a complex tensor
-        if dtype != None and  vsa == "FHRR":
+        if dtype != None and vsa == "FHRR":
             dtype = fhrr_type_conversion[dtype]
 
         factory_kwargs = {"device": device, "dtype": dtype}

--- a/torchhd/embeddings.py
+++ b/torchhd/embeddings.py
@@ -32,7 +32,7 @@ from torch.nn.parameter import Parameter
 import torchhd.functional as functional
 from torchhd.tensors.base import VSATensor
 from torchhd.tensors.map import MAPTensor
-from torchhd.tensors.fhrr import FHRRTensor
+from torchhd.tensors.fhrr import FHRRTensor, type_conversion as fhrr_type_conversion
 from torchhd.tensors.hrr import HRRTensor
 from torchhd.types import VSAOptions
 
@@ -1017,7 +1017,6 @@ class FractionalPower(nn.Module):
         dtype=None,
         requires_grad: bool = False,
     ) -> None:
-        factory_kwargs = {"device": device, "dtype": dtype}
         super(FractionalPower, self).__init__()
 
         self.in_features = in_features  # data dimensions
@@ -1031,6 +1030,16 @@ class FractionalPower(nn.Module):
             )
 
         self.vsa_tensor = functional.get_vsa_tensor_class(vsa)
+
+        # If a specific dtype is specified make sure it is supported by the VSA model
+        if dtype != None and dtype not in self.vsa_tensor.supported_dtypes:
+            raise ValueError(f"dtype {dtype} not supported by {vsa}")
+        
+        # The internal weights/phases are stored as floats even if the output is a complex tensor
+        if dtype != None and  vsa == "FHRR":
+            dtype = fhrr_type_conversion[dtype]
+
+        factory_kwargs = {"device": device, "dtype": dtype}
 
         # If the distribution is a string use the presets in predefined_kernels
         if isinstance(distribution, str):

--- a/torchhd/tests/test_embeddings.py
+++ b/torchhd/tests/test_embeddings.py
@@ -560,14 +560,14 @@ class TestFractionalPower:
         x = torch.randn(2, embedding)
         y = emb(x)
         assert y.shape == (2, dimensions)
-        
+
         if vsa == "HRR":
             assert y.dtype == torch.float32
         elif vsa == "FHRR":
             assert y.dtype == torch.complex64
         else:
             return
-        
+
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_dtype(self, dtype):
         dimensions = 1456
@@ -575,9 +575,13 @@ class TestFractionalPower:
 
         if dtype not in {torch.float32, torch.float64}:
             with pytest.raises(ValueError):
-                embeddings.FractionalPower(embedding, dimensions, vsa="HRR", dtype=dtype)  
-        else:        
-            emb = embeddings.FractionalPower(embedding, dimensions, vsa="HRR", dtype=dtype)
+                embeddings.FractionalPower(
+                    embedding, dimensions, vsa="HRR", dtype=dtype
+                )
+        else:
+            emb = embeddings.FractionalPower(
+                embedding, dimensions, vsa="HRR", dtype=dtype
+            )
 
             x = torch.randn(13, embedding, dtype=dtype)
             y = emb(x)
@@ -586,9 +590,13 @@ class TestFractionalPower:
 
         if dtype not in {torch.complex64, torch.complex128}:
             with pytest.raises(ValueError):
-                embeddings.FractionalPower(embedding, dimensions, vsa="FHRR", dtype=dtype)  
-        else:        
-            emb = embeddings.FractionalPower(embedding, dimensions, vsa="FHRR", dtype=dtype)
+                embeddings.FractionalPower(
+                    embedding, dimensions, vsa="FHRR", dtype=dtype
+                )
+        else:
+            emb = embeddings.FractionalPower(
+                embedding, dimensions, vsa="FHRR", dtype=dtype
+            )
 
             x = torch.randn(13, embedding, dtype=fhrr_type_conversion[dtype])
             y = emb(x)
@@ -613,7 +621,7 @@ class TestFractionalPower:
         x = torch.randn(1, 3)
         y = emb(x)
         assert y.shape == (1, 1000)
-    
+
     def test_custom_dist_2d(self):
         # Phase distribution for periodic Sinc kernel
         class HexDisc(torch.distributions.Categorical):
@@ -634,7 +642,7 @@ class TestFractionalPower:
 
             def sample(self, sample_shape=torch.Size()):
                 return self.phases[super().sample(sample_shape), :]
-            
+
         kernel_shape = HexDisc()
         band = 3.0
 
@@ -642,4 +650,3 @@ class TestFractionalPower:
         x = torch.randn(5, 2)
         y = emb(x)
         assert y.shape == (5, 1000)
-


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!-- Link the issue (if any) that will be resolved by the changes -->

The current validation of the provided `dtype` expects a value to be passed  but the default is `None`. Moreover, for the `FHRR` VSA model, the `dtype` used for the weights/phases stored by the `FractionalPower` embedding are different from the hypervector returned by the embedding, i.e., `complex64` means that the weights are `float32`.

This resolves issue #147.

## Checklist
- [x] I added/updated documentation for the changes.
- [x] I have thoroughly tested the changes.