### PR TITLE
Remove unneccessary Random in EMG example

### DIFF
--- a/examples/emg_hand_gestures.py
+++ b/examples/emg_hand_gestures.py
@@ -33,13 +33,11 @@ class Encoder(nn.Module):
         super(Encoder, self).__init__()
 
         self.channels = embeddings.Random(channels, out_features)
-        self.timestamps = embeddings.Random(timestamps, out_features)
         self.signals = embeddings.Level(NUM_LEVELS, out_features, high=20)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         signal = self.signals(input)
         samples = torchhd.bind(signal, self.channels.weight.unsqueeze(0))
-        samples = torchhd.bind(samples, self.timestamps.weight.unsqueeze(1))
 
         samples = torchhd.multiset(samples)
         sample_hv = torchhd.ngrams(samples, n=N_GRAM_SIZE)


### PR DESCRIPTION
The EMG hand gestures example uses a Random embedding to encode the timestamp information. However, the paper original does not use such embedding, and the timing is encoded by permuting the spatial samples. Fix #155.
