### PR TITLE
Ensure hamming similarity inputs are vsa tensors

### DIFF
--- a/torchhd/functional.py
+++ b/torchhd/functional.py
@@ -1018,6 +1018,9 @@ def hamming_similarity(input: VSATensor, others: VSATensor) -> LongTensor:
                 [5, 3, 6]])
 
     """
+    input = ensure_vsa_tensor(input)
+    others = ensure_vsa_tensor(others)
+
     if input.dim() > 1 and others.dim() > 1:
         equals = input.unsqueeze(-2) == others.unsqueeze(-3)
         return torch.sum(equals, dim=-1, dtype=torch.long)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!-- Link the issue (if any) that will be resolved by the changes -->

All other functions in `functional.py` first ensure that the input is a `VSATensor`. This PR ensures that the hamming similarity follows this convention. This fixes #157 . 

## Checklist
- [ ] I added/updated documentation for the changes.
- [ ] I have thoroughly tested the changes.
