### PR TITLE
Allow custom dtype for some VSA similarity functions

### DIFF
--- a/torchhd/functional.py
+++ b/torchhd/functional.py
@@ -893,7 +893,7 @@ def hard_quantize(input: Tensor):
     return torch.where(input > 0, positive, negative)
 
 
-def dot_similarity(input: VSATensor, others: VSATensor) -> VSATensor:
+def dot_similarity(input: VSATensor, others: VSATensor, **kwargs) -> VSATensor:
     """Dot product between the input vector and each vector in others.
 
     Aliased as ``torchhd.dot``.
@@ -938,13 +938,13 @@ def dot_similarity(input: VSATensor, others: VSATensor) -> VSATensor:
     """
     input = ensure_vsa_tensor(input)
     others = ensure_vsa_tensor(others)
-    return input.dot_similarity(others)
+    return input.dot_similarity(others, **kwargs)
 
 
 dot = dot_similarity
 
 
-def cosine_similarity(input: VSATensor, others: VSATensor) -> VSATensor:
+def cosine_similarity(input: VSATensor, others: VSATensor, **kwargs) -> VSATensor:
     """Cosine similarity between the input vector and each vector in others.
 
     Aliased as ``torchhd.cos``.
@@ -987,7 +987,7 @@ def cosine_similarity(input: VSATensor, others: VSATensor) -> VSATensor:
     """
     input = ensure_vsa_tensor(input)
     others = ensure_vsa_tensor(others)
-    return input.cosine_similarity(others)
+    return input.cosine_similarity(others, **kwargs)
 
 
 cos = cosine_similarity

--- a/torchhd/tensors/bsbc.py
+++ b/torchhd/tensors/bsbc.py
@@ -334,9 +334,10 @@ class BSBCTensor(VSATensor):
         """
         return torch.roll(self, shifts=shifts, dims=-1)
 
-    def dot_similarity(self, others: "BSBCTensor") -> Tensor:
+    def dot_similarity(self, others: "BSBCTensor", *, dtype=None) -> Tensor:
         """Inner product with other hypervectors"""
-        dtype = torch.get_default_dtype()
+        if dtype is None:
+            dtype = torch.get_default_dtype()
 
         if self.dim() > 1 and others.dim() > 1:
             equals = self.unsqueeze(-2) == others.unsqueeze(-3)
@@ -344,10 +345,10 @@ class BSBCTensor(VSATensor):
 
         return torch.sum(self == others, dim=-1, dtype=dtype)
 
-    def cosine_similarity(self, others: "BSBCTensor") -> Tensor:
+    def cosine_similarity(self, others: "BSBCTensor", *, dtype=None) -> Tensor:
         """Cosine similarity with other hypervectors"""
         magnitude = self.size(-1)
-        return self.dot_similarity(others) / magnitude
+        return self.dot_similarity(others, dtype=dtype) / magnitude
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/torchhd/tensors/bsc.py
+++ b/torchhd/tensors/bsc.py
@@ -426,10 +426,11 @@ class BSCTensor(VSATensor):
         """
         return super().roll(shifts=shifts, dims=-1)
 
-    def dot_similarity(self, others: "BSCTensor") -> Tensor:
+    def dot_similarity(self, others: "BSCTensor", *, dtype=None) -> Tensor:
         """Inner product with other hypervectors."""
-        dtype = torch.get_default_dtype()
         device = self.device
+        if dtype is None:
+            dtype = torch.get_default_dtype()
 
         min_one = torch.tensor(-1.0, dtype=dtype, device=device)
         plus_one = torch.tensor(1.0, dtype=dtype, device=device)
@@ -441,7 +442,7 @@ class BSCTensor(VSATensor):
             others_as_bipolar = others_as_bipolar.transpose(-2, -1)
         return torch.matmul(self_as_bipolar, others_as_bipolar)
 
-    def cosine_similarity(self, others: "BSCTensor") -> Tensor:
+    def cosine_similarity(self, others: "BSCTensor", *, dtype=None) -> Tensor:
         """Cosine similarity with other hypervectors."""
         d = self.size(-1)
-        return self.dot_similarity(others) / d
+        return self.dot_similarity(others, dtype=dtype) / d

--- a/torchhd/tensors/fhrr.py
+++ b/torchhd/tensors/fhrr.py
@@ -379,6 +379,7 @@ class FHRRTensor(VSATensor):
         """Inner product with other hypervectors"""
         if others.dim() >= 2:
             others = others.transpose(-2, -1)
+            
         return torch.real(torch.matmul(self, torch.conj(others)))
 
     def cosine_similarity(self, others: "FHRRTensor", *, eps=1e-08) -> Tensor:

--- a/torchhd/tensors/fhrr.py
+++ b/torchhd/tensors/fhrr.py
@@ -379,7 +379,7 @@ class FHRRTensor(VSATensor):
         """Inner product with other hypervectors"""
         if others.dim() >= 2:
             others = others.transpose(-2, -1)
-            
+
         return torch.real(torch.matmul(self, torch.conj(others)))
 
     def cosine_similarity(self, others: "FHRRTensor", *, eps=1e-08) -> Tensor:

--- a/torchhd/tensors/hrr.py
+++ b/torchhd/tensors/hrr.py
@@ -366,7 +366,7 @@ class HRRTensor(VSATensor):
         """Inner product with other hypervectors"""
         if others.dim() >= 2:
             others = others.transpose(-2, -1)
-            
+
         return torch.matmul(self, others)
 
     def cosine_similarity(self, others: "HRRTensor", *, eps=1e-08) -> Tensor:

--- a/torchhd/tensors/hrr.py
+++ b/torchhd/tensors/hrr.py
@@ -366,6 +366,7 @@ class HRRTensor(VSATensor):
         """Inner product with other hypervectors"""
         if others.dim() >= 2:
             others = others.transpose(-2, -1)
+            
         return torch.matmul(self, others)
 
     def cosine_similarity(self, others: "HRRTensor", *, eps=1e-08) -> Tensor:

--- a/torchhd/tensors/map.py
+++ b/torchhd/tensors/map.py
@@ -347,10 +347,12 @@ class MAPTensor(VSATensor):
 
         if others.dim() >= 2:
             others = others.transpose(-2, -1)
-        
+
         return torch.matmul(self.to(dtype), others.to(dtype))
 
-    def cosine_similarity(self, others: "MAPTensor", *, dtype=None, eps=1e-08) -> Tensor:
+    def cosine_similarity(
+        self, others: "MAPTensor", *, dtype=None, eps=1e-08
+    ) -> Tensor:
         """Cosine similarity with other hypervectors"""
         if dtype is None:
             dtype = torch.get_default_dtype()

--- a/torchhd/tensors/map.py
+++ b/torchhd/tensors/map.py
@@ -340,16 +340,20 @@ class MAPTensor(VSATensor):
 
         return torch.clamp(self, min=-kappa, max=kappa)
 
-    def dot_similarity(self, others: "MAPTensor") -> Tensor:
+    def dot_similarity(self, others: "MAPTensor", *, dtype=None) -> Tensor:
         """Inner product with other hypervectors"""
-        dtype = torch.get_default_dtype()
+        if dtype is None:
+            dtype = torch.get_default_dtype()
+
         if others.dim() >= 2:
             others = others.transpose(-2, -1)
+        
         return torch.matmul(self.to(dtype), others.to(dtype))
 
-    def cosine_similarity(self, others: "MAPTensor", *, eps=1e-08) -> Tensor:
+    def cosine_similarity(self, others: "MAPTensor", *, dtype=None, eps=1e-08) -> Tensor:
         """Cosine similarity with other hypervectors"""
-        dtype = torch.get_default_dtype()
+        if dtype is None:
+            dtype = torch.get_default_dtype()
 
         self_dot = torch.sum(self * self, dim=-1, dtype=dtype)
         self_mag = torch.sqrt(self_dot)
@@ -363,4 +367,4 @@ class MAPTensor(VSATensor):
             magnitude = self_mag * others_mag
 
         magnitude = torch.clamp(magnitude, min=eps)
-        return self.dot_similarity(others) / magnitude
+        return self.dot_similarity(others, dtype=dtype) / magnitude

--- a/torchhd/tests/basis_hv/test_circular_hv.py
+++ b/torchhd/tests/basis_hv/test_circular_hv.py
@@ -114,7 +114,9 @@ class Testcircular:
 
         elif vsa == "FHRR":
             mag = hv.abs()
-            assert torch.allclose(mag, torch.tensor(1.0, dtype=mag.dtype), rtol=0.0001, atol=0.0001)
+            assert torch.allclose(
+                mag, torch.tensor(1.0, dtype=mag.dtype), rtol=0.0001, atol=0.0001
+            )
 
         elif vsa == "BSBC":
             assert torch.all((hv >= 0) | (hv < 1024)).item()

--- a/torchhd/tests/basis_hv/test_circular_hv.py
+++ b/torchhd/tests/basis_hv/test_circular_hv.py
@@ -114,7 +114,7 @@ class Testcircular:
 
         elif vsa == "FHRR":
             mag = hv.abs()
-            assert torch.allclose(mag, torch.tensor(1.0, dtype=mag.dtype))
+            assert torch.allclose(mag, torch.tensor(1.0, dtype=mag.dtype), rtol=0.0001, atol=0.0001)
 
         elif vsa == "BSBC":
             assert torch.all((hv >= 0) | (hv < 1024)).item()

--- a/torchhd/tests/test_similarities.py
+++ b/torchhd/tests/test_similarities.py
@@ -229,7 +229,6 @@ class TestDotSimilarity:
         similarity = functional.dot_similarity(hv, hv, dtype=torch.int16)
         assert similarity.dtype == torch.int16
 
-
     @pytest.mark.parametrize("vsa", vsa_tensors)
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_device(self, vsa, dtype):

--- a/torchhd/tests/test_similarities.py
+++ b/torchhd/tests/test_similarities.py
@@ -198,6 +198,38 @@ class TestDotSimilarity:
         else:
             assert similarity.dtype == torch.get_default_dtype()
 
+    def test_custom_dtype(self):
+        hv = functional.random(3, 100, "BSBC", block_size=1024)
+        similarity = functional.dot_similarity(hv, hv)
+        assert similarity.dtype == torch.get_default_dtype()
+
+        similarity = functional.dot_similarity(hv, hv, dtype=torch.float64)
+        assert similarity.dtype == torch.float64
+
+        similarity = functional.dot_similarity(hv, hv, dtype=torch.int16)
+        assert similarity.dtype == torch.int16
+
+        hv = functional.random(3, 100, "MAP")
+        similarity = functional.dot_similarity(hv, hv)
+        assert similarity.dtype == torch.get_default_dtype()
+
+        similarity = functional.dot_similarity(hv, hv, dtype=torch.float64)
+        assert similarity.dtype == torch.float64
+
+        similarity = functional.dot_similarity(hv, hv, dtype=torch.int16)
+        assert similarity.dtype == torch.int16
+
+        hv = functional.random(3, 100, "BSC")
+        similarity = functional.dot_similarity(hv, hv)
+        assert similarity.dtype == torch.get_default_dtype()
+
+        similarity = functional.dot_similarity(hv, hv, dtype=torch.float64)
+        assert similarity.dtype == torch.float64
+
+        similarity = functional.dot_similarity(hv, hv, dtype=torch.int16)
+        assert similarity.dtype == torch.int16
+
+
     @pytest.mark.parametrize("vsa", vsa_tensors)
     @pytest.mark.parametrize("dtype", torch_dtypes)
     def test_device(self, vsa, dtype):


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!-- Link the issue (if any) that will be resolved by the changes -->

With this PR a dtype can be specified for the return of the `MAPTensor`, `BSBCTensor`, and `BSCTensor`. The computation of the similarity value is also performed in this dtype. One therefore has to be careful not to make the precision too low to avoid overflows. This PR closes #158 .

## Checklist
- [ ] I added/updated documentation for the changes.
- [x] I have thoroughly tested the changes.
