### PR TITLE
Fix `randsel` probability is opposite of documentation

### DIFF
--- a/torchhd/functional.py
+++ b/torchhd/functional.py
@@ -1104,7 +1104,7 @@ def randsel(
     other = ensure_vsa_tensor(other)
 
     select = torch.empty_like(input, dtype=torch.bool)
-    select.bernoulli_(1 - p, generator=generator)
+    select.bernoulli_(p, generator=generator)
     return input.where(select, other)
 
 

--- a/torchhd/tests/test_operations.py
+++ b/torchhd/tests/test_operations.py
@@ -272,7 +272,7 @@ class TestRandsel:
         else:
             a, b = functional.random(2, 1024, vsa, dtype=dtype, generator=generator)
         res = functional.randsel(a, b, p=0, generator=generator)
-        assert torch.all(a == res)
+        assert torch.all(b == res)
 
         if vsa == "BSBC":
             a, b = functional.random(
@@ -281,7 +281,7 @@ class TestRandsel:
         else:
             a, b = functional.random(2, 1024, vsa, dtype=dtype, generator=generator)
         res = functional.randsel(a, b, p=1, generator=generator)
-        assert torch.all(b == res)
+        assert torch.all(a == res)
 
         if vsa == "BSBC":
             a, b = functional.random(


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!-- Link the issue (if any) that will be resolved by the changes -->

Selects elements from the `input` tensor if `p=1` and from the `other` tensor when `p=0`. Fixes #161 .

## Checklist
- [x] I added/updated documentation for the changes.
- [x] I have thoroughly tested the changes.
