### PR TITLE
Add similarity calculation for all pairs of vectors in the unit test …

### DIFF
--- a/torchhd/tests/basis_hv/test_circular_hv.py
+++ b/torchhd/tests/basis_hv/test_circular_hv.py
@@ -127,15 +127,18 @@ class Testcircular:
             )
         else:
             hv = functional.circular(8, 1000000, vsa, generator=generator, dtype=dtype)
-        sims = functional.cosine_similarity(hv[0], hv)
-        sims_diff = sims[:-1] - sims[1:]
-        assert torch.all(
-            sims_diff.sign() == torch.tensor([1, 1, 1, 1, -1, -1, -1])
-        ), "second half must get more similar"
+        
+        for i in range(8-1):
+            sims = functional.cosine_similarity(hv[0], hv)
+            sims_diff = sims[:-1] - sims[1:]
+            assert torch.all(
+                sims_diff.sign() == torch.tensor([1, 1, 1, 1, -1, -1, -1])
+            ), f"element #{i}: second half must get more similar"
 
-        assert torch.allclose(
-            sims_diff.abs(), torch.tensor(0.25, dtype=sims_diff.dtype), atol=0.005
-        ), "similarity decreases linearly"
+            assert torch.allclose(
+                sims_diff.abs(), torch.tensor(0.25, dtype=sims_diff.dtype), atol=0.005
+            ), f"element #{i}: similarity decreases linearly"
+            hv = torch.roll(hv,1,0)
 
     @pytest.mark.parametrize("sparsity", [0.0, 0.1, 0.756, 1.0])
     @pytest.mark.parametrize("dtype", torch_dtypes)


### PR DESCRIPTION
…for the circular function

As mentioned in https://github.com/hyperdimensional-computing/torchhd/issues/108#issuecomment-2413286496 the circular test just test the similarity between first vector and other vectors while we have to test the similarity between all pairs of vectors
  
## Description

Added a loop wrapping the previous code and rolling the list of vectors in the end of the loop.



## Checklist
- [ ] I added/updated documentation for the changes.
- [ ] I have thoroughly tested the changes.
